### PR TITLE
Do not show closed IM tabs at launch

### DIFF
--- a/slackclient.cpp
+++ b/slackclient.cpp
@@ -205,7 +205,7 @@ SlackChannel::SlackChannel(SlackClient *client, const QJsonValueRef &sourceRef)
     id          = source["id"].toString();
     if (source.contains("is_im") && source["is_im"].toBool()) {
         is_im = true;
-        is_member = true;
+        is_member = source["is_open"].toBool();;
         is_channel = false;
         is_group = false;
         name = client->user(source["user"].toString()).name;


### PR DESCRIPTION
According to [1], the property `is_open` shows if the DM channel is
open. The API documentation doesn't give the list of API methods that
provides the `is_open` property but it looks like we have this
information in response to `rtm.start`...

[1] https://api.slack.com/types/im